### PR TITLE
Improve CodeIgniter system path resolution

### DIFF
--- a/index.php
+++ b/index.php
@@ -6,21 +6,37 @@
  * application and system folders and then includes the core framework.
  *
  * CodeIgniter uses the Model-View-Controller (MVC) pattern to keep
- * presentation, business logic and data layers separate【907651110350654†L1383-L1413】.
- */
+ * presentation, business logic and data layers separate.
+*/
 
-$system_path = '../system';
-$application_folder = 'application';
+$application_folder = __DIR__.'/application';
 
-/*
- * Resolve the system and application paths.  You may need to update these
- * variables depending on where you place CodeIgniter's `system` folder.
- */
-$system_path = rtrim(str_replace('\\', '/', $system_path), '/');
-$application_folder = rtrim(str_replace('\\', '/', $application_folder), '/');
+// Attempt to locate the CodeIgniter system folder in common locations.
+$system_path = null;
+$path_options = [
+    __DIR__.'/system',
+    __DIR__.'/../system',
+];
 
-define('BASEPATH', $system_path.'/');
-define('APPPATH', $application_folder.'/');
+foreach ($path_options as $path) {
+    $resolved = realpath($path);
+    if ($resolved !== false && is_dir($resolved)) {
+        $system_path = $resolved;
+        break;
+    }
+}
+
+if ($system_path === null) {
+    exit('Your system folder path does not appear to be set correctly. ' .
+         'Please ensure the "system" directory exists in this directory ' .
+         'or one level above.');
+}
+
+$system_path = rtrim(str_replace('\\', '/', $system_path), '/') . '/';
+$application_folder = rtrim(str_replace('\\', '/', $application_folder), '/') . '/';
+
+define('BASEPATH', $system_path);
+define('APPPATH', $application_folder);
 define('ENVIRONMENT', 'development');
 
 // Load the bootstrap file from the system folder.


### PR DESCRIPTION
## Summary
- search for CodeIgniter `system` folder in common locations and resolve with `realpath`
- exit with a clear message when the framework folder is missing

## Testing
- `php -l index.php`


------
https://chatgpt.com/codex/tasks/task_e_68c679fe13c8832080ffe45ea9aa1472