### PR TITLE
Improve CodeIgniter system path resolution

### DIFF
--- a/index.php
+++ b/index.php
@@ -6,22 +6,30 @@
  * application and system folders and then includes the core framework.
  *
  * CodeIgniter uses the Model-View-Controller (MVC) pattern to keep
- * presentation, business logic and data layers separate【907651110350654†L1383-L1413】.
+ * presentation, business logic and data layers separate.
  */
 
-$system_path = '../system';
-$application_folder = 'application';
+$application_folder = __DIR__.'/application';
 
-/*
- * Resolve the system and application paths.  You may need to update these
- * variables depending on where you place CodeIgniter's `system` folder.
- */
-$system_path = rtrim(str_replace('\\', '/', $system_path), '/');
-$application_folder = rtrim(str_replace('\\', '/', $application_folder), '/');
+// Determine the CodeIgniter system folder expected in this directory.
+$system_path = __DIR__.'/system';
 
-define('BASEPATH', $system_path.'/');
-define('APPPATH', $application_folder.'/');
+if (!is_dir($system_path)) {
+    $expected = rtrim(str_replace('\\', '/', $system_path), '/');
+    exit(
+        'Your system folder path does not appear to be set correctly. '
+        . 'Please ensure the "system" directory exists in: '
+        . $expected
+    );
+}
+
+$system_path = rtrim(str_replace('\\', '/', realpath($system_path)), '/') . '/';
+$application_folder = rtrim(str_replace('\\', '/', realpath($application_folder) ?: $application_folder), '/') . '/';
+
+define('BASEPATH', $system_path);
+define('APPPATH', $application_folder);
 define('ENVIRONMENT', 'development');
 
 // Load the bootstrap file from the system folder.
 require_once BASEPATH.'core/CodeIgniter.php';
+


### PR DESCRIPTION
## Summary
- ensure system directory lookup only resolves the local folder
- harden path normalization and clarify error when system folder is missing
- display expected system directory path when missing

## Testing
- `php -l index.php`


------
https://chatgpt.com/codex/tasks/task_e_68c679fe13c8832080ffe45ea9aa1472